### PR TITLE
Merge Menu with placeholders

### DIFF
--- a/astrolume.py
+++ b/astrolume.py
@@ -74,7 +74,10 @@ class MainMenu(scenes.Scene):
 		DrawTextEx(a["astrolume:fonts.Prompt-Regular"],const.VERSION.encode(),(20,s_height-30),20,0,GRAY) # text,x,y,size,color
 		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.singleplayer"].encode(),(20,150),30,0,WHITE)
 		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.multiplayer"].encode(),(20,180),30,0,WHITE)
-	def Event(self,man):
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.settings"].encode(),(20,210),30,0,WHITE)
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.credits"].encode(),(20,240),30,0,WHITE)
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.exit"].encode(),(20,270),30,0,WHITE)
+	def Input(self,man):
 		pass
 sceneman.addScene("MAIN_MENU",MainMenu)
 sceneman.setScene("MAIN_MENU")

--- a/astrolume.py
+++ b/astrolume.py
@@ -124,6 +124,8 @@ class MainMenu(scenes.Scene):
 				print(ID)
 			case "exit":
 				closeWindow = True
+			case _:
+				raise NotImplementedError("Unimplemented ID in MainMenu.ButtonPress")
 sceneman.addScene("MAIN_MENU",MainMenu)
 sceneman.setScene("MAIN_MENU")
 

--- a/astrolume.py
+++ b/astrolume.py
@@ -60,6 +60,18 @@ def HandleMusic(music):
 	UpdateMusicStream(music)
 	SetMusicVolume(music,settings.config["volume"]["master"]*settings.config["volume"]["music"])
 
+def DrawButtonRectangle(x,y,w,h,color,hovercolor,clickcolor,ID,func):
+	r = None
+	if CheckCollisionPointRec(GetMousePosition(),[x,y,w,h]):
+		color = hovercolor
+		if IsMouseButtonDown(0):
+			color = clickcolor
+		if IsMouseButtonReleased(0):
+			func(ID)
+		r = MOUSE_CURSOR_POINTING_HAND
+	DrawRectangle(x,y,w,h,color)
+	return r
+
 sceneman = scenes.SceneManager()
 class MainMenu(scenes.Scene):
 	def __init__(self,name):
@@ -70,19 +82,54 @@ class MainMenu(scenes.Scene):
 		if not IsMusicStreamPlaying(menuMusic):
 			PlayMusicStream(a["astrolume:music.lastingPeace_extended_ambient"])
 	def Render(self,man):
+		cursor = MOUSE_CURSOR_DEFAULT
+		ClearBackground(BLACK)
 		DrawTextEx(a["astrolume:fonts.Prompt-ExtraLightItalic"],const.NAME.encode(),(20,10),60,10,WHITE) # text,x,y,size,color
 		DrawTextEx(a["astrolume:fonts.Prompt-Regular"],const.VERSION.encode(),(20,s_height-30),20,0,GRAY) # text,x,y,size,color
+
+		cursor = DrawButtonRectangle(15,150,205,30,[255,255,255,5],[255,255,255,20],[255,255,255,50],("singleplayer",man),self.ButtonPress) or cursor
+		DrawRectangle(13,150,2,30,[255,255,255,255])
 		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.singleplayer"].encode(),(20,150),30,0,WHITE)
-		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.multiplayer"].encode(),(20,180),30,0,WHITE)
-		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.settings"].encode(),(20,210),30,0,WHITE)
-		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.credits"].encode(),(20,240),30,0,WHITE)
-		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.exit"].encode(),(20,270),30,0,WHITE)
+
+		cursor = DrawButtonRectangle(15,181,205,30,[255,255,255,5],[255,255,255,20],[255,255,255,50],("multiplayer",man),self.ButtonPress) or cursor
+		DrawRectangle(13,181,2,30,[255,255,255,255])
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.multiplayer"].encode(),(20,181),30,0,WHITE)
+
+		cursor = DrawButtonRectangle(15,212,205,30,[255,255,255,5],[255,255,255,20],[255,255,255,50],("settings",man),self.ButtonPress) or cursor
+		DrawRectangle(13,212,2,30,[255,255,255,255])
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.settings"].encode(),(20,212),30,0,WHITE)
+
+		cursor = DrawButtonRectangle(15,243,205,30,[255,255,255,5],[255,255,255,20],[255,255,255,50],("credits",man),self.ButtonPress) or cursor
+		DrawRectangle(13,243,2,30,[255,255,255,255])
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.credits"].encode(),(20,243),30,0,WHITE)
+
+		cursor = DrawButtonRectangle(15,274,205,30,[255,255,255,5],[255,255,255,20],[255,255,255,50],("exit",man),self.ButtonPress) or cursor
+		DrawRectangle(13,274,2,30,[255,255,255,255])
+		DrawTextEx(a["astrolume:fonts.Prompt-Light"],locale.lang["gui.menu.exit"].encode(),(20,274),30,0,WHITE)
+		SetMouseCursor(cursor)
 	def Input(self,man):
 		pass
+	def ButtonPress(self,ID):
+		global closeWindow
+		man = ID[1]
+		ID = ID[0]
+		match ID:
+			case "singleplayer":
+				print("singleplayer")
+			case "multiplayer":
+				print(ID)
+			case "settings":
+				print(ID)
+			case "credits":
+				print(ID)
+			case "exit":
+				closeWindow = True
 sceneman.addScene("MAIN_MENU",MainMenu)
 sceneman.setScene("MAIN_MENU")
 
-while not WindowShouldClose():
+closeWindow = False
+
+while not (WindowShouldClose() or closeWindow):
 	s_width,s_height = (GetScreenWidth(),GetScreenHeight())
 	sceneman.PrepShader(s_width,s_height)
 	sceneman.Render()

--- a/scenes.py
+++ b/scenes.py
@@ -21,7 +21,7 @@ class Scene:
 		raise NotImplementedError(f"({self.name}) Scene.Process")
 	def Render(self,man):
 		raise NotImplementedError(f"({self.name}) Scene.Render")
-	def Event(self,man):
+	def Input(self,man):
 		raise NotImplementedError(f"({self.name}) Scene.Event")
 
 class SceneManager:
@@ -85,6 +85,6 @@ class SceneManager:
 		ClearBackground(BLACK)
 		DrawTextureFlip(self.renderTextures[renderTextureId].texture,0,0,WHITE)
 		EndDrawing()
-	def Event(self):
+	def Input(self):
 		if not self.active_scene: raise SceneError("No active scene!")
-		return self.active_scene.Event(self)
+		return self.active_scene.Input(self)


### PR DESCRIPTION
Placeholders `print(ID)`s are used in MainMenu.ButtonPress instead of switching to scenes that don't exist yet.